### PR TITLE
feat: cache b58 id

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,9 +17,14 @@ class PeerId {
       assert(privKey.public.bytes.equals(pubKey.bytes), 'inconsistent arguments')
     }
 
-    this.id = id
+    this._id = id
+    this._idB58String = ''
     this._privKey = privKey
     this._pubKey = pubKey
+  }
+
+  get id () {
+    return this._id
   }
 
   get privKey () {
@@ -61,7 +66,7 @@ class PeerId {
   // of go-ipfs for its config file
   toJSON () {
     return {
-      id: mh.toB58String(this.id),
+      id: this.toB58String(),
       privKey: toB64Opt(this.marshalPrivKey()),
       pubKey: toB64Opt(this.marshalPubKey())
     }
@@ -77,7 +82,11 @@ class PeerId {
   }
 
   toB58String () {
-    return mh.toB58String(this.id)
+    if (!this._idB58String) {
+      this._idB58String = mh.toB58String(this.id)
+    }
+
+    return this._idB58String
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -18,13 +18,17 @@ class PeerId {
     }
 
     this._id = id
-    this._idB58String = ''
+    this._idB58String = mh.toB58String(this.id)
     this._privKey = privKey
     this._pubKey = pubKey
   }
 
   get id () {
     return this._id
+  }
+
+  set id (val) {
+    throw new Error('Id is immutable')
   }
 
   get privKey () {
@@ -82,10 +86,6 @@ class PeerId {
   }
 
   toB58String () {
-    if (!this._idB58String) {
-      this._idB58String = mh.toB58String(this.id)
-    }
-
     return this._idB58String
   }
 }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -29,6 +29,17 @@ describe('PeerId', () => {
     })
   })
 
+  it('throws on changing the id', (done) => {
+    PeerId.create((err, id) => {
+      expect(err).to.not.exist
+      expect(id.toB58String().length).to.equal(46)
+      expect(() => {
+        id.id = new Buffer('hello')
+      }).to.throw(/immutable/)
+      done()
+    })
+  })
+
   it('recreate an Id from Hex string', () => {
     const id = PeerId.createFromHexString(testIdHex)
     expect(testIdBytes).to.deep.equal(id.id)


### PR DESCRIPTION
While investigating slow performance in js-ipfs I discovered that there are too many calls to `mh.toB58String`. This is the start of reducing the number of those calls. 