### PR TITLE
Always add public key to constructor if possible, Fix for undefined pubKey in remote peers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -202,7 +202,7 @@ exports.createFromPrivKey = function (key, callback) {
       return callback(err)
     }
 
-    callback(null, new PeerId(digest, privKey))
+    callback(null, new PeerId(digest, privKey, privKey.public))
   })
 }
 

--- a/test/peer-id.spec.js
+++ b/test/peer-id.spec.js
@@ -105,7 +105,7 @@ describe('PeerId', () => {
 
   it('Non-default # of bits', function (done) {
     // rsa is slow atm
-    this.timeout(20000)
+    this.timeout(100000)
     PeerId.create({ bits: 1024 }, (err, shortId) => {
       expect(err).to.not.exist()
       PeerId.create({ bits: 4096 }, (err, longId) => {

--- a/test/peer-id.spec.js
+++ b/test/peer-id.spec.js
@@ -85,6 +85,7 @@ describe('PeerId', () => {
       PeerId.createFromPrivKey(encoded, (err, id2) => {
         expect(err).to.not.exist()
         expect(testIdB58String).to.equal(id2.toB58String())
+        expect(id.marshalPubKey()).to.deep.equal(id2.marshalPubKey())
         done()
       })
     })


### PR DESCRIPTION
hey @diasdavid , I noticed that whenever ipfs creates an Id , it usually uses `peerId.createFromPrivKey` , and this means you can add pubkey to the `PeerId` constructor call.

This is useful because it means the pubKey is available without ever triggering `get pubKey()`. so when this peer connects to another, the `peer-id` object would have the pubKey included. and won't equal `undefined` like the current situation.
![pub included](https://i.imgur.com/afVsVKA.jpg)

I Also added a line to the tests to check if the pub key is valid.