### PR TITLE
update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,14 +33,14 @@
   },
   "homepage": "https://github.com/libp2p/js-peer-id",
   "devDependencies": {
-    "aegir": "^12.2.0",
+    "aegir": "^12.3.0",
     "chai": "^4.1.2",
     "dirty-chai": "^2.0.1",
     "pre-commit": "^1.2.2"
   },
   "dependencies": {
     "async": "^2.6.0",
-    "libp2p-crypto": "~0.10.4",
+    "libp2p-crypto": "~0.11.0",
     "lodash": "^4.17.4",
     "multihashes": "~0.4.12"
   },


### PR DESCRIPTION
`libp2p-keychain` needs new release that uses the latest `libp2p-crypto` 