### PR TITLE
Add flow type signatures.

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,8 @@
+[ignore]
+.*/node_modules/documentation/*
+
+[libs]
+
+[include]
+
+[options]

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "async": "^2.6.0",
     "libp2p-crypto": "~0.11.0",
     "lodash": "^4.17.4",
-    "multihashes": "~0.4.12"
+    "multihashes": "~0.4.12",
+    "callback.flow": "1.0.0"
   },
   "repository": {
     "type": "git",

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -1,0 +1,44 @@
+// @flow
+
+import type { Callback } from "callback.flow"
+import * as crypto from "libp2p-crypto"
+
+const { RsaPublicKey, RsaPrivateKey } = crypto.key.rsa
+
+export interface JSONPeerId {
+  id: string;
+  privKey: string;
+  pubKey: string;
+}
+
+export interface PeerId {
+  id: Buffer;
+  privKey: RsaPrivateKey;
+  pubKey: RsaPublicKey;
+
+  toJSON(): JSONPeerId;
+  toPrint(): JSONPeerId;
+  toB58String(): string;
+  toBytes(): Buffer;
+  toHexString(): string;
+  isEqual(PeerId): boolean;
+  marshalPubKey(): Buffer;
+  marshalPrivKey(): Buffer;
+  isValid(Callback<Error>): void;
+}
+
+export type CreateOptions = {
+  bits?: number
+}
+
+declare export default {
+  create(CreateOptions, Callback<Error, PeerId>): void,
+  create(Callback<Error, PeerId>): void,
+  createFromHexString(string): PeerId,
+  createFromBytes(Buffer): PeerId,
+  createFromB58String(string): PeerId,
+  createFromPubKey(string | Buffer, Callback<Error, PeerId>): void,
+  createFromPrivKey(string | Buffer, Callback<Error, PeerId>): void,
+  createFromJSON(JSONPeerId, Callback<Error, PeerId>): void,
+  isPeerId(mixed): boolean
+}


### PR DESCRIPTION
As dive into ipfs / libp2p code base I struggle to guess what are all the things passed around. Types as in [flow](http://flow.org/) (or typescript for that matter) simplify learning of how things are connected significantly. There for I decided to contribute type signatures to the code base as I digg through it. 

### What's up with all these .js.flow files ?

Unfortunately flow project has yet to come up with coherent story of how to provide type annotations for third party libraries. In my experience adding `.js.flow` files works best out of all options, that is because flow type checker when gives a precedent to `/path/to/file.js.flow` over `/path/to/file.js` which essentially provides a way to provide type annotations for non-flow typed package such that just using it as dependency will satisfy both type checker and run-time.

It's far from ideal given that `.js` and `.js.flow` files can get out of sync but then again unless you're open to adopt flow this is the best option IMO.

### Depends on https://github.com/multiformats/js-multiaddr/pull/51

  
  