### PR TITLE
feat: add class-is module

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "async": "^2.6.1",
+    "class-is": "^1.1.0",
     "libp2p-crypto": "~0.13.0",
     "lodash": "^4.17.10",
     "multihashes": "~0.4.13"

--- a/src/index.js
+++ b/src/index.js
@@ -133,7 +133,9 @@ class PeerId {
   }
 }
 
-exports = module.exports = withIs(PeerId, { className: 'PeerId', symbolName: '@libp2p/js-peer-id/PeerId' })
+const PeerIdWithIs = withIs(PeerId, { className: 'PeerId', symbolName: '@libp2p/js-peer-id/PeerId' })
+
+exports = module.exports = PeerIdWithIs
 
 // generation
 exports.create = function (opts, callback) {
@@ -154,20 +156,20 @@ exports.create = function (opts, callback) {
       return callback(err)
     }
 
-    callback(null, new PeerId(digest, privKey))
+    callback(null, new PeerIdWithIs(digest, privKey))
   })
 }
 
 exports.createFromHexString = function (str) {
-  return new PeerId(mh.fromHexString(str))
+  return new PeerIdWithIs(mh.fromHexString(str))
 }
 
 exports.createFromBytes = function (buf) {
-  return new PeerId(buf)
+  return new PeerIdWithIs(buf)
 }
 
 exports.createFromB58String = function (str) {
-  return new PeerId(mh.fromB58String(str))
+  return new PeerIdWithIs(mh.fromB58String(str))
 }
 
 // Public Key input will be a buffer
@@ -196,7 +198,7 @@ exports.createFromPubKey = function (key, callback) {
       return callback(err)
     }
 
-    callback(null, new PeerId(digest, null, pubKey))
+    callback(null, new PeerIdWithIs(digest, null, pubKey))
   })
 }
 
@@ -228,7 +230,7 @@ exports.createFromPrivKey = function (key, callback) {
       return callback(err)
     }
 
-    callback(null, new PeerId(digest, privKey, privKey.public))
+    callback(null, new PeerIdWithIs(digest, privKey, privKey.public))
   })
 }
 
@@ -279,10 +281,10 @@ exports.createFromJSON = function (obj, callback) {
         return callback(new Error('Id and private key do not match'))
       }
 
-      callback(null, new PeerId(id, priv, pub))
+      callback(null, new PeerIdWithIs(id, priv, pub))
     })
   } else {
-    callback(null, new PeerId(id, null, pub))
+    callback(null, new PeerIdWithIs(id, null, pub))
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ const mh = require('multihashes')
 const crypto = require('libp2p-crypto')
 const assert = require('assert')
 const waterfall = require('async/waterfall')
+const withIs = require('class-is')
 
 class PeerId {
   constructor (id, privKey, pubKey) {
@@ -132,7 +133,7 @@ class PeerId {
   }
 }
 
-exports = module.exports = PeerId
+exports = module.exports = withIs(PeerId, { className: 'PeerId', symbolName: '@libp2p/js-peer-id/PeerId' })
 
 // generation
 exports.create = function (opts, callback) {


### PR DESCRIPTION
The `instance of` fails when using different versions of a module. This way, we end up with problems using this in other places, such as [js-ipfs/core/ipns/publisher.js#L54](https://github.com/ipfs/js-ipfs/blob/master/src/core/ipns/publisher.js#L54).

In the context of [js-ipfs/issues/1615](https://github.com/ipfs/js-ipfs/issues/1615). This is not a problem now, as it is only occurring with `interface-datastore` key. However, it may occur in a future release of this module.