### PR TITLE
Add support for specifying keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The public key is a base64 encoded string of a protobuf containing an RSA DER bu
 ```JavaScript
 const PeerId = require('peer-id')
 
-PeerId.create({ bits: 1024 }, (err, id) => {
+PeerId.create({ type: 'rsa', bits: 1024 }, (err, id) => {
   if (err) { throw err }
   console.log(JSON.stringify(id.toJSON(), null, 2))
 })
@@ -128,7 +128,9 @@ The key format is detailed in [libp2p-crypto](https://github.com/libp2p/js-libp2
 
 Generates a new Peer ID, complete with public/private keypair.
 
-- `opts: Object`: Default: `{bits: 2048}`
+- `opts: Object`: Default: `{bits: 2048, type: 'rsa'}`
+- `opts.bits Number`: Default: `2048`
+- `opts.type: String`: Default: `rsa`, One of `['rsa', 'ed25519', 'secp256k1']`
 - `callback: Function`
 
 Calls back `callback` with `err, id`.

--- a/package.json
+++ b/package.json
@@ -33,16 +33,16 @@
   },
   "homepage": "https://github.com/libp2p/js-peer-id",
   "devDependencies": {
-    "aegir": "^14.0.0",
+    "aegir": "^15.3.1",
     "chai": "^4.1.2",
     "dirty-chai": "^2.0.1"
   },
   "dependencies": {
     "async": "^2.6.1",
     "class-is": "^1.1.0",
-    "libp2p-crypto": "~0.13.0",
+    "libp2p-crypto": "~0.14.0",
     "lodash": "^4.17.10",
-    "multihashes": "~0.4.13"
+    "multihashes": "~0.4.14"
   },
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -137,17 +137,28 @@ const PeerIdWithIs = withIs(PeerId, { className: 'PeerId', symbolName: '@libp2p/
 
 exports = module.exports = PeerIdWithIs
 
-// generation
+/**
+ * Creates a new PeerId
+ *
+ * @param {object} opts
+ * @param {string} opts.type The type of key to generate. One of ['rsa', 'ed25519', 'secp256k1'], case insensitive.
+ * @param {number} opts.bits Size of the key to generate
+ * @param {function(Error, PeerId)} callback
+ * @returns {void}
+ */
 exports.create = function (opts, callback) {
   if (typeof opts === 'function') {
     callback = opts
     opts = {}
   }
-  opts = opts || {}
-  opts.bits = opts.bits || 2048
+  const defaults = {
+    bits: 2048,
+    type: 'RSA'
+  }
+  opts = Object.assign({}, defaults, opts)
 
   waterfall([
-    (cb) => crypto.keys.generateKeyPair('RSA', opts.bits, cb),
+    (cb) => crypto.keys.generateKeyPair(opts.type, opts.bits, cb),
     (privKey, cb) => privKey.public.hash((err, digest) => {
       cb(err, digest, privKey)
     })

--- a/test/peer-id.spec.js
+++ b/test/peer-id.spec.js
@@ -308,4 +308,57 @@ describe('PeerId', () => {
       expect(() => new PeerId('hello world')).to.throw(/invalid id/)
     })
   })
+
+  describe('key types', () => {
+    it('should default to an rsa key based peer id', (done) => {
+      PeerId.create({
+        bits: 512
+      }, (err, peerId) => {
+        expect(err).to.not.exist()
+        expect(peerId).to.exist()
+        expect(peerId.pubKey).to.be.instanceof(crypto.keys.supportedKeys.rsa.RsaPublicKey)
+        expect(peerId.privKey).to.be.instanceof(crypto.keys.supportedKeys.rsa.RsaPrivateKey)
+        done()
+      })
+    })
+
+    it('should create an ed25519 key based peer id', (done) => {
+      PeerId.create({
+        type: 'ed25519',
+        bits: 512
+      }, (err, peerId) => {
+        expect(err).to.not.exist()
+        expect(peerId).to.exist()
+        expect(peerId.pubKey).to.be.instanceof(crypto.keys.supportedKeys.ed25519.Ed25519PublicKey)
+        expect(peerId.privKey).to.be.instanceof(crypto.keys.supportedKeys.ed25519.Ed25519PrivateKey)
+        done()
+      })
+    })
+
+    it('should create an rsa key based peer id', (done) => {
+      PeerId.create({
+        type: 'rsa',
+        bits: 512
+      }, (err, peerId) => {
+        expect(err).to.not.exist()
+        expect(peerId).to.exist()
+        expect(peerId.pubKey).to.be.instanceof(crypto.keys.supportedKeys.rsa.RsaPublicKey)
+        expect(peerId.privKey).to.be.instanceof(crypto.keys.supportedKeys.rsa.RsaPrivateKey)
+        done()
+      })
+    })
+
+    it('should create a secp256k1 key based peer id', (done) => {
+      PeerId.create({
+        type: 'secp256k1',
+        bits: 512
+      }, (err, peerId) => {
+        expect(err).to.not.exist()
+        expect(peerId).to.exist()
+        expect(peerId.pubKey).to.be.instanceof(crypto.keys.supportedKeys.secp256k1.Secp256k1PublicKey)
+        expect(peerId.privKey).to.be.instanceof(crypto.keys.supportedKeys.secp256k1.Secp256k1PrivateKey)
+        done()
+      })
+    })
+  })
 })


### PR DESCRIPTION
`libp2p-crypto` already supports multiple key formats, this PR exposes that by adding the type option to `.create`.  This will allow users to create the other key types more easily.