### PR TITLE
feat: async await

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 - [API](#api)
   - [Create](#create)
     - [`new PeerId(id[, privKey, pubKey])`](#new-peeridid-privkey-pubkey)
-    - [`create([opts], callback)`](#createopts-callback)
+    - [`create([opts])`](#createopts)
   - [Import](#import)
     - [`createFromHexString(str)`](#createfromhexstringstr)
     - [`createFromBytes(buf)`](#createfrombytesbuf)
@@ -57,11 +57,10 @@ The public key is a base64 encoded string of a protobuf containing an RSA DER bu
 ```JavaScript
 const PeerId = require('peer-id')
 
-PeerId.create({ bits: 1024 }, (err, id) => {
-  if (err) { throw err }
-  console.log(JSON.stringify(id.toJSON(), null, 2))
-})
+const id = await PeerId.create({ bits: 1024 })
+console.log(JSON.stringify(id.toJSON(), null, 2))
 ```
+
 ```bash
 {
   "id": "Qma9T5YraSnpRDZqRR4krcSJabThc8nwZuJV3LercPHufi",
@@ -124,14 +123,13 @@ const PeerId = require('peer-id')
 
 The key format is detailed in [libp2p-crypto](https://github.com/libp2p/js-libp2p-crypto).
 
-### `create([opts], callback)`
+### `create([opts])`
 
 Generates a new Peer ID, complete with public/private keypair.
 
 - `opts: Object`: Default: `{bits: 2048}`
-- `callback: Function`
 
-Calls back `callback` with `err, id`.
+Returns `Promise<PeerId>`.
 
 ## Import
 
@@ -139,13 +137,19 @@ Calls back `callback` with `err, id`.
 
 Creates a Peer ID from hex string representing the key's multihash.
 
+Returns `PeerId.
+
 ### `createFromBytes(buf)`
 
 Creates a Peer ID from a buffer representing the key's multihash.
 
+Returns `PeerId`.
+
 ### `createFromB58String(str)`
 
 Creates a Peer ID from a Base58 string representing the key's multihash.
+
+Returns `PeerId`.
 
 ### `createFromPubKey(pubKey)`
 
@@ -153,17 +157,23 @@ Creates a Peer ID from a Base58 string representing the key's multihash.
 
 Creates a Peer ID from a buffer containing a public key.
 
+Returns `Promise<PeerId>`.
+
 ### `createFromPrivKey(privKey)`
 
 - `privKey: Buffer`
 
 Creates a Peer ID from a buffer containing a private key.
 
+Returns `Promise<PeerId>`.
+
 ### `createFromJSON(obj)`
 
 - `obj.id: String` - The multihash encoded in `base58`
 - `obj.pubKey: String` - The public key in protobuf format, encoded in `base64`
 - `obj.privKey: String` - The private key in protobuf format, encoded in `base64`
+
+Returns `Promise<PeerId>`.
 
 ## Export
 

--- a/package.json
+++ b/package.json
@@ -34,15 +34,14 @@
   },
   "homepage": "https://github.com/libp2p/js-peer-id",
   "devDependencies": {
-    "aegir": "^18.2.2",
-    "bundlesize": "~0.17.1",
+    "aegir": "^19.0.5",
+    "bundlesize": "~0.18.0",
     "chai": "^4.2.0",
     "dirty-chai": "^2.0.1"
   },
   "dependencies": {
-    "async": "^2.6.2",
     "class-is": "^1.1.0",
-    "libp2p-crypto": "~0.16.1",
+    "libp2p-crypto": "~0.17.0",
     "multihashes": "~0.4.14"
   },
   "repository": {

--- a/src/bin.js
+++ b/src/bin.js
@@ -4,10 +4,9 @@
 
 const PeerId = require('./index.js')
 
-PeerId.create((err, id) => {
-  if (err) {
-    throw err
-  }
+async function main () {
+  const id = await PeerId.create()
+  console.log(JSON.stringify(id.toJSON(), null, 2)) // eslint-disable-line no-console
+}
 
-  console.log(JSON.stringify(id.toJSON(), null, 2))
-})
+main()

--- a/test/peer-id.spec.js
+++ b/test/peer-id.spec.js
@@ -8,7 +8,6 @@ chai.use(dirtyChai)
 const expect = chai.expect
 const crypto = require('libp2p-crypto')
 const mh = require('multihashes')
-const parallel = require('async/parallel')
 
 const PeerId = require('../src')
 
@@ -32,34 +31,24 @@ describe('PeerId', () => {
     expect(PeerId).to.throw(Error)
   })
 
-  it('create a new id', (done) => {
-    PeerId.create(testOpts, (err, id) => {
-      expect(err).to.not.exist()
-      expect(id.toB58String().length).to.equal(46)
-      done()
-    })
+  it('create a new id', async () => {
+    const id = await PeerId.create(testOpts)
+    expect(id.toB58String().length).to.equal(46)
   })
 
-  it('isPeerId', (done) => {
-    PeerId.create(testOpts, (err, id) => {
-      expect(err).to.not.exist()
-      expect(PeerId.isPeerId(id)).to.equal(true)
-      expect(PeerId.isPeerId('aaa')).to.equal(false)
-      expect(PeerId.isPeerId(Buffer.from('batatas'))).to.equal(false)
-      done()
-    })
+  it('isPeerId', async () => {
+    const id = await PeerId.create(testOpts)
+    expect(PeerId.isPeerId(id)).to.equal(true)
+    expect(PeerId.isPeerId('aaa')).to.equal(false)
+    expect(PeerId.isPeerId(Buffer.from('batatas'))).to.equal(false)
   })
 
-  it('throws on changing the id', function (done) {
-    this.timeout(10000)
-    PeerId.create(testOpts, (err, id) => {
-      expect(err).to.not.exist()
-      expect(id.toB58String().length).to.equal(46)
-      expect(() => {
-        id.id = Buffer.from('hello')
-      }).to.throw(/immutable/)
-      done()
-    })
+  it('throws on changing the id', async () => {
+    const id = await PeerId.create(testOpts)
+    expect(id.toB58String().length).to.equal(46)
+    expect(() => {
+      id.id = Buffer.from('hello')
+    }).to.throw(/immutable/)
   })
 
   it('recreate an Id from Hex string', () => {
@@ -77,72 +66,44 @@ describe('PeerId', () => {
     expect(testIdB58String).to.equal(id.toB58String())
   })
 
-  it('Recreate from a Public Key', (done) => {
-    PeerId.createFromPubKey(testId.pubKey, (err, id) => {
-      expect(err).to.not.exist()
-      expect(testIdB58String).to.equal(id.toB58String())
-      done()
-    })
+  it('Recreate from a Public Key', async () => {
+    const id = await PeerId.createFromPubKey(testId.pubKey)
+    expect(testIdB58String).to.equal(id.toB58String())
   })
 
-  it('Recreate from a Private Key', (done) => {
-    PeerId.createFromPrivKey(testId.privKey, (err, id) => {
-      expect(err).to.not.exist()
-      expect(testIdB58String).to.equal(id.toB58String())
-
-      const encoded = Buffer.from(testId.privKey, 'base64')
-      PeerId.createFromPrivKey(encoded, (err, id2) => {
-        expect(err).to.not.exist()
-        expect(testIdB58String).to.equal(id2.toB58String())
-        expect(id.marshalPubKey()).to.deep.equal(id2.marshalPubKey())
-        done()
-      })
-    })
+  it('Recreate from a Private Key', async () => {
+    const id = await PeerId.createFromPrivKey(testId.privKey)
+    expect(testIdB58String).to.equal(id.toB58String())
+    const encoded = Buffer.from(testId.privKey, 'base64')
+    const id2 = await PeerId.createFromPrivKey(encoded)
+    expect(testIdB58String).to.equal(id2.toB58String())
+    expect(id.marshalPubKey()).to.deep.equal(id2.marshalPubKey())
   })
 
-  it('Compare generated ID with one created from PubKey', (done) => {
-    PeerId.create(testOpts, (err, id1) => {
-      expect(err).to.not.exist()
-
-      PeerId.createFromPubKey(id1.marshalPubKey(), (err, id2) => {
-        expect(err).to.not.exist()
-        expect(id1.id).to.be.eql(id2.id)
-        done()
-      })
-    })
+  it('Compare generated ID with one created from PubKey', async () => {
+    const id1 = await PeerId.create(testOpts)
+    const id2 = await PeerId.createFromPubKey(id1.marshalPubKey())
+    expect(id1.id).to.be.eql(id2.id)
   })
 
-  it('Works with default options', function (done) {
+  it('Works with default options', async function () {
     this.timeout(10000)
-    PeerId.create((err, id) => {
-      expect(err).to.not.exist()
-      expect(id.toB58String().length).to.equal(46)
-      done()
-    })
+    const id = await PeerId.create()
+    expect(id.toB58String().length).to.equal(46)
   })
 
-  it('Non-default # of bits', function (done) {
+  it('Non-default # of bits', async function () {
     this.timeout(1000 * 60)
-    PeerId.create(testOpts, (err, shortId) => {
-      expect(err).to.not.exist()
-      PeerId.create({ bits: 1024 }, (err, longId) => {
-        expect(err).to.not.exist()
-        expect(shortId.privKey.bytes.length).is.below(longId.privKey.bytes.length)
-        done()
-      })
-    })
+    const shortId = await PeerId.create(testOpts)
+    const longId = await PeerId.create({ bits: 1024 })
+    expect(shortId.privKey.bytes.length).is.below(longId.privKey.bytes.length)
   })
 
-  it('Pretty printing', (done) => {
-    PeerId.create(testOpts, (err, id1) => {
-      expect(err).to.not.exist()
-      PeerId.createFromPrivKey(id1.toJSON().privKey, (err, id2) => {
-        expect(err).to.not.exist()
-        expect(id1.toPrint()).to.be.eql(id2.toPrint())
-        expect(id1.toPrint()).to.equal('<peer.ID ' + id1.toB58String().substr(2, 6) + '>')
-        done()
-      })
-    })
+  it('Pretty printing', async () => {
+    const id1 = await PeerId.create(testOpts)
+    const id2 = await PeerId.createFromPrivKey((id1.toJSON()).privKey)
+    expect(id1.toPrint()).to.be.eql(id2.toPrint())
+    expect(id1.toPrint()).to.equal('<peer.ID ' + id1.toB58String().substr(2, 6) + '>')
   })
 
   it('toBytes', () => {
@@ -150,120 +111,88 @@ describe('PeerId', () => {
     expect(id.toBytes().toString('hex')).to.equal(testIdBytes.toString('hex'))
   })
 
-  it('isEqual', (done) => {
-    parallel([
-      (cb) => PeerId.create(testOpts, cb),
-      (cb) => PeerId.create(testOpts, cb)
-    ], (err, ids) => {
-      expect(err).to.not.exist()
-      expect(ids[0].isEqual(ids[0])).to.equal(true)
-      expect(ids[0].isEqual(ids[1])).to.equal(false)
-      expect(ids[0].isEqual(ids[0].id)).to.equal(true)
-      expect(ids[0].isEqual(ids[1].id)).to.equal(false)
-      done()
-    })
+  it('isEqual', async () => {
+    const ids = await Promise.all([
+      PeerId.create(testOpts),
+      PeerId.create(testOpts)
+    ])
+
+    expect(ids[0].isEqual(ids[0])).to.equal(true)
+    expect(ids[0].isEqual(ids[1])).to.equal(false)
+    expect(ids[0].isEqual(ids[0].id)).to.equal(true)
+    expect(ids[0].isEqual(ids[1].id)).to.equal(false)
   })
 
   describe('fromJSON', () => {
-    it('full node', (done) => {
-      PeerId.create(testOpts, (err, id) => {
-        expect(err).to.not.exist()
-
-        PeerId.createFromJSON(id.toJSON(), (err, other) => {
-          expect(err).to.not.exist()
-          expect(id.toB58String()).to.equal(other.toB58String())
-          expect(id.privKey.bytes).to.eql(other.privKey.bytes)
-          expect(id.pubKey.bytes).to.eql(other.pubKey.bytes)
-          done()
-        })
-      })
+    it('full node', async () => {
+      const id = await PeerId.create(testOpts)
+      const other = await PeerId.createFromJSON(id.toJSON())
+      expect(id.toB58String()).to.equal(other.toB58String())
+      expect(id.privKey.bytes).to.eql(other.privKey.bytes)
+      expect(id.pubKey.bytes).to.eql(other.pubKey.bytes)
     })
 
-    it('only id', (done) => {
-      crypto.keys.generateKeyPair('RSA', 1024, (err, key) => {
-        expect(err).to.not.exist()
-        key.public.hash((err, digest) => {
-          expect(err).to.not.exist()
-
-          const id = PeerId.createFromBytes(digest)
-          expect(id.privKey).to.not.exist()
-          expect(id.pubKey).to.not.exist()
-
-          PeerId.createFromJSON(id.toJSON(), (err, other) => {
-            expect(err).to.not.exist()
-            expect(id.toB58String()).to.equal(other.toB58String())
-            done()
-          })
-        })
-      })
+    it('only id', async () => {
+      const key = await crypto.keys.generateKeyPair('RSA', 1024)
+      const digest = await key.public.hash()
+      const id = PeerId.createFromBytes(digest)
+      expect(id.privKey).to.not.exist()
+      expect(id.pubKey).to.not.exist()
+      const other = await PeerId.createFromJSON(id.toJSON())
+      expect(id.toB58String()).to.equal(other.toB58String())
     })
 
-    it('go interop', (done) => {
-      PeerId.createFromJSON(goId, (err, id) => {
-        expect(err).to.not.exist()
-        id.privKey.public.hash((err, digest) => {
-          expect(err).to.not.exist()
-          expect(mh.toB58String(digest)).to.eql(goId.id)
-          done()
-        })
-      })
+    it('go interop', async () => {
+      const id = await PeerId.createFromJSON(goId)
+      const digest = await id.privKey.public.hash()
+      expect(mh.toB58String(digest)).to.eql(goId.id)
     })
   })
 
-  it('set privKey (valid)', (done) => {
-    PeerId.create(testOpts, (err, peerId) => {
-      expect(err).to.not.exist()
-      peerId.privKey = peerId._privKey
-      peerId.isValid(done)
-    })
+  it('set privKey (valid)', async () => {
+    const peerId = await PeerId.create(testOpts)
+    peerId.privKey = peerId._privKey
+    expect(peerId.isValid()).to.equal(true)
   })
 
-  it('set pubKey (valid)', (done) => {
-    PeerId.create(testOpts, (err, peerId) => {
-      expect(err).to.not.exist()
-      peerId.pubKey = peerId._pubKey
-      peerId.isValid(done)
-    })
+  it('set pubKey (valid)', async () => {
+    const peerId = await PeerId.create(testOpts)
+    peerId.pubKey = peerId._pubKey
+    expect(peerId.isValid()).to.equal(true)
   })
 
-  it('set privKey (invalid)', (done) => {
-    PeerId.create(testOpts, (err, peerId) => {
-      expect(err).to.not.exist()
-      peerId.privKey = Buffer.from('bufff')
-      peerId.isValid((err) => {
-        expect(err).to.exist()
-        done()
-      })
-    })
+  it('set privKey (invalid)', async () => {
+    const peerId = await PeerId.create(testOpts)
+    peerId.privKey = Buffer.from('bufff')
+    expect(peerId.isValid()).to.equal(false)
   })
 
-  it('set pubKey (invalid)', (done) => {
-    PeerId.create(testOpts, (err, peerId) => {
-      expect(err).to.not.exist()
-      peerId.pubKey = Buffer.from('buffff')
-      peerId.isValid((err) => {
-        expect(err).to.exist()
-        done()
-      })
-    })
+  it('set pubKey (invalid)', async () => {
+    const peerId = await PeerId.create(testOpts)
+    peerId.pubKey = Buffer.from('bufff')
+    expect(peerId.isValid()).to.equal(false)
   })
 
   describe('returns error via cb instead of crashing', () => {
-    const garbage = [Buffer.from('00010203040506070809', 'hex'), {}, null, false, undefined, true, 1, 0, Buffer.from(''), 'aGVsbG93b3JsZA==', 'helloworld', '']
+    const garbage = [
+      Buffer.from('00010203040506070809', 'hex'),
+      {}, null, false, undefined, true, 1, 0,
+      Buffer.from(''), 'aGVsbG93b3JsZA==', 'helloworld', ''
+    ]
 
     const fncs = ['createFromPubKey', 'createFromPrivKey', 'createFromJSON']
 
-    garbage.forEach(garbage => {
-      fncs.forEach(fnc => {
-        it(fnc + '(' + util.inspect(garbage) + ')', cb => {
-          PeerId[fnc](garbage, (err, res) => {
+    for (const gb of garbage) {
+      for (const fn of fncs) {
+        it(`${fn} (${util.inspect(gb)})`, async () => {
+          try {
+            await PeerId[fn](gb)
+          } catch (err) {
             expect(err).to.exist()
-            expect(res).to.not.exist()
-            cb()
-          })
+          }
         })
-      })
-    })
+      }
+    }
   })
 
   describe('throws on inconsistent data', () => {
@@ -271,37 +200,30 @@ describe('PeerId', () => {
     let k2
     let k3
 
-    before((done) => {
-      parallel([
-        (cb) => crypto.keys.generateKeyPair('RSA', 512, cb),
-        (cb) => crypto.keys.generateKeyPair('RSA', 512, cb),
-        (cb) => crypto.keys.generateKeyPair('RSA', 512, cb)
-      ], (err, keys) => {
-        expect(err).to.not.exist()
+    before(async () => {
+      const keys = await Promise.all([
+        crypto.keys.generateKeyPair('RSA', 512),
+        crypto.keys.generateKeyPair('RSA', 512),
+        crypto.keys.generateKeyPair('RSA', 512)
+      ])
 
-        k1 = keys[0]
-        k2 = keys[1]
-        k3 = keys[2]
-        done()
-      })
+      k1 = keys[0]
+      k2 = keys[1]
+      k3 = keys[2]
     })
 
-    it('missmatch private - public key', (done) => {
-      k1.public.hash((err, digest) => {
-        expect(err).to.not.exist()
-        expect(() => new PeerId(digest, k1, k2.public))
-          .to.throw(/inconsistent arguments/)
-        done()
-      })
+    it('missmatch private - public key', async () => {
+      const digest = await k1.public.hash()
+      expect(() => {
+        new PeerId(digest, k1, k2.public) // eslint-disable-line no-new
+      }).to.throw(/inconsistent arguments/)
     })
 
-    it('missmatch id - private - public key', (done) => {
-      k1.public.hash((err, digest) => {
-        expect(err).to.not.exist()
-        expect(() => new PeerId(digest, k1, k3.public))
-          .to.throw(/inconsistent arguments/)
-        done()
-      })
+    it('missmatch id - private - public key', async () => {
+      const digest = await k1.public.hash()
+      expect(() => {
+        new PeerId(digest, k1, k3.public) // eslint-disable-line no-new
+      }).to.throw(/inconsistent arguments/)
     })
 
     it('invalid id', () => {


### PR DESCRIPTION
More background about this effort: https://github.com/ipfs/js-ipfs/issues/1670.

* [x] **Depends** on https://github.com/libp2p/js-libp2p-crypto/pull/131

~Despite some `createX` function not needing `async`, I added it to all of them to make them consistent. Otherwise we would have half returning a Promise and another half returning a PeerId~