### PR TITLE
Support creating from Secp256k1 / harmonize algorithm with Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The public key is a base64 encoded string of a protobuf containing an RSA DER bu
 ```JavaScript
 const PeerId = require('peer-id')
 
-const id = await PeerId.create({ bits: 1024 })
+const id = await PeerId.create({ bits: 1024, keyType: 'rsa' })
 console.log(JSON.stringify(id.toJSON(), null, 2))
 ```
 
@@ -127,7 +127,7 @@ The key format is detailed in [libp2p-crypto](https://github.com/libp2p/js-libp2
 
 Generates a new Peer ID, complete with public/private keypair.
 
-- `opts: Object`: Default: `{bits: 2048}`
+- `opts: Object`: Default: `{bits: 2048, keyType: 'rsa'}`
 
 Returns `Promise<PeerId>`.
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "class-is": "^1.1.0",
     "libp2p-crypto": "~0.17.0",
-    "multihashes": "~0.4.14"
+    "multihashes": "~0.4.15"
   },
   "repository": {
     "type": "git",

--- a/test/peer-id.spec.js
+++ b/test/peer-id.spec.js
@@ -36,6 +36,12 @@ describe('PeerId', () => {
     expect(id.toB58String().length).to.equal(46)
   })
 
+  it('can be created for a Secp256k1 key', async () => {
+    const id = await PeerId.create({ keyType: 'secp256k1', bits: 256 })
+    const expB58 = mh.toB58String(mh.encode(id.pubKey.bytes, 'identity'))
+    expect(id.toB58String()).to.equal(expB58)
+  })
+
   it('isPeerId', async () => {
     const id = await PeerId.create(testOpts)
     expect(PeerId.isPeerId(id)).to.equal(true)
@@ -78,6 +84,20 @@ describe('PeerId', () => {
     const id2 = await PeerId.createFromPrivKey(encoded)
     expect(testIdB58String).to.equal(id2.toB58String())
     expect(id.marshalPubKey()).to.deep.equal(id2.marshalPubKey())
+  })
+
+  it('can be created from a Secp256k1 public key', async () => {
+    const privKey = await crypto.keys.generateKeyPair('secp256k1', 256)
+    const id = await PeerId.createFromPubKey(privKey.public.bytes)
+    const expB58 = mh.toB58String(mh.encode(id.pubKey.bytes, 'identity'))
+    expect(id.toB58String()).to.equal(expB58)
+  })
+
+  it('can be created from a Secp256k1 private key', async () => {
+    const privKey = await crypto.keys.generateKeyPair('secp256k1', 256)
+    const id = await PeerId.createFromPrivKey(privKey.bytes)
+    const expB58 = mh.toB58String(mh.encode(id.pubKey.bytes, 'identity'))
+    expect(id.toB58String()).to.equal(expB58)
   })
 
   it('Compare generated ID with one created from PubKey', async () => {


### PR DESCRIPTION
Support creating peer IDs from Secp256k1 type keys and harmonize ID algorithm with Go so that for public keys of <= 42 bytes length, we inline the public key.

Required by https://github.com/libp2p/interop/pull/21