### PR TITLE
chore: revert async dep change

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,14 +34,14 @@
   },
   "homepage": "https://github.com/libp2p/js-peer-id",
   "devDependencies": {
-    "aegir": "^18.2.2",
+    "aegir": "^20.0.0",
     "bundlesize": "~0.17.1",
     "chai": "^4.2.0",
     "dirty-chai": "^2.0.1"
   },
   "dependencies": {
     "libp2p-crypto": "~0.16.1",
-    "async": "^3.0.1",
+    "async": "^2.6.2",
     "class-is": "^1.1.0",
     "multihashes": "~0.4.15"
   },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "libp2p-crypto": "~0.16.1",
-    "async": "^2.6.2",
+    "async": "^2.6.3",
     "class-is": "^1.1.0",
     "multihashes": "~0.4.15"
   },

--- a/src/bin.js
+++ b/src/bin.js
@@ -9,5 +9,6 @@ PeerId.create((err, id) => {
     throw err
   }
 
+  // eslint-disable-next-line
   console.log(JSON.stringify(id.toJSON(), null, 2))
 })


### PR DESCRIPTION
This reverts async to the 2.6 line as 3.0 has issues https://github.com/libp2p/js-peer-id/issues/96#issuecomment-513873738.

**Note** this merge is into a 0.12.x branch. Since 0.13 is already out and is leveraging the async/await codebase, we need to release from the latest 0.12 tag. 0.12.x is based off of that latest release. Once released, I will delete that branch as well.