### PR TITLE
support inline public keys

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,6 +48,13 @@ class PeerId {
     if (this._privKey) {
       return this._privKey.public
     }
+
+    const decoded = mh.decode(this.id)
+
+    if (decoded.name === 'identity') {
+      this._pubKey = cryptoKeys.unmarshalPublicKey(decoded.digest)
+      return this._pubKey
+    }
   }
 
   set pubKey (pubKey) {

--- a/test/peer-id.spec.js
+++ b/test/peer-id.spec.js
@@ -42,6 +42,12 @@ describe('PeerId', () => {
     expect(id.toB58String()).to.equal(expB58)
   })
 
+  it('can get the public key from a Secp256k1 key', async () => {
+    const original = await PeerId.create({ keyType: 'secp256k1', bits: 256 })
+    const newId = PeerId.createFromB58String(original.toB58String())
+    expect(original.pubKey.bytes).to.eql(newId.pubKey.bytes)
+  })
+
   it('isPeerId', async () => {
     const id = await PeerId.create(testOpts)
     expect(PeerId.isPeerId(id)).to.equal(true)


### PR DESCRIPTION
We are having trouble because we are using Secp256k1 from Go in our pubsub messages. Go does not set the "key" field of a message when publishing with an inline key. So javascript rejects any signed Go message (using Secp256k1).

There is a TODO here: https://github.com/libp2p/js-libp2p-pubsub/blob/master/src/message/sign.js#L76-L77

Well, hopefully this PR allows for that TODO to happen. 

All this does is check if the peerID has identity encoding and if it does, attempt to recover the public key from the encoding.