### PR TITLE
feat: deprecate isEqual in favor of equals

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@
 
 ## Table of Contents
 
+- [peer-id](#peer-id)
+  - [Lead Maintainer](#lead-maintainer)
+  - [Table of Contents](#table-of-contents)
 - [Description](#description)
 - [Example](#example)
 - [Installation](#installation)
@@ -37,13 +40,18 @@
     - [`createFromPubKey(pubKey)`](#createfrompubkeypubkey)
     - [`createFromPrivKey(privKey)`](#createfromprivkeyprivkey)
     - [`createFromJSON(obj)`](#createfromjsonobj)
+    - [`createFromProtobuf(buf)`](#createfromprotobufbuf)
   - [Export](#export)
+    - [`toHexString()`](#tohexstring)
     - [`toBytes()`](#tobytes)
     - [`toString()`](#tostring)
     - [`toB58String()`](#tob58string)
-    - [`toHexString()`](#tohexstring)
     - [`toJSON()`](#tojson)
+    - [`marshal(excludePrivateKey)`](#marshalexcludeprivatekey)
+    - [`marshalPubKey()`](#marshalpubkey)
     - [`toPrint()`](#toprint)
+    - [`equals(id)`](#equalsid)
+    - [`isEqual(id)`](#isequalid)
 - [License](#license)
 
 # Description
@@ -256,7 +264,14 @@ Returns the Peer ID as a printable string without the `Qm` prefix.
 
 Example: `<peer.ID xxxxxx>`
 
+### `equals(id)`
+
+Returns `true` if the given PeerId is equal to the current instance.
+
+- `id` can be a PeerId or a Buffer containing the id
+
 ### `isEqual(id)`
+**Deprecation Notice**: Use [`equals`](#equalsid), `isEqual` will be removed in 0.14.0.
 
 - `id` can be a PeerId or a Buffer containing the id
 

--- a/src/index.js
+++ b/src/index.js
@@ -133,7 +133,12 @@ class PeerId {
     return this._idCIDString
   }
 
-  isEqual (id) {
+  /**
+   * Checks the equality of `this` peer against a given PeerId.
+   * @param {Buffer|PeerId} id
+   * @returns {boolean}
+   */
+  equals (id) {
     if (Buffer.isBuffer(id)) {
       return this.id.equals(id)
     } else if (id.id) {
@@ -141,6 +146,16 @@ class PeerId {
     } else {
       throw new Error('not valid Id')
     }
+  }
+
+  /**
+   * Checks the equality of `this` peer against a given PeerId.
+   * @deprecated Use `.equals`
+   * @param {Buffer|PeerId} id
+   * @returns {boolean}
+   */
+  isEqual (id) {
+    return this.equals(id)
   }
 
   /*

--- a/test/peer-id.spec.js
+++ b/test/peer-id.spec.js
@@ -231,6 +231,18 @@ describe('PeerId', () => {
     expect(ids[0].isEqual(ids[1].id)).to.equal(false)
   })
 
+  it('equals', async () => {
+    const ids = await Promise.all([
+      PeerId.create(testOpts),
+      PeerId.create(testOpts)
+    ])
+
+    expect(ids[0].equals(ids[0])).to.equal(true)
+    expect(ids[0].equals(ids[1])).to.equal(false)
+    expect(ids[0].equals(ids[0].id)).to.equal(true)
+    expect(ids[0].equals(ids[1].id)).to.equal(false)
+  })
+
   describe('fromJSON', () => {
     it('full node', async () => {
       const id = await PeerId.create(testOpts)


### PR DESCRIPTION
Resolves https://github.com/libp2p/js-peer-id/issues/94.

This deprecates isEqual in favor of `equals`. I added a deprecation notice to the readme about removing support for this whenever we release 0.14. If this looks good I will create an issue to track its removal.