### PR TITLE
fix: catch errors thrown by multihash decode

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,11 +55,12 @@ class PeerId {
 
       if (decoded.name === 'identity') {
         this._pubKey = cryptoKeys.unmarshalPublicKey(decoded.digest)
-        return this._pubKey
       }
     } catch (_) {
       // Ignore, there is no valid public key
     }
+
+    return this._pubKey
   }
 
   set pubKey (pubKey) {

--- a/src/index.js
+++ b/src/index.js
@@ -50,11 +50,15 @@ class PeerId {
       return this._privKey.public
     }
 
-    const decoded = mh.decode(this.id)
+    try {
+      const decoded = mh.decode(this.id)
 
-    if (decoded.name === 'identity') {
-      this._pubKey = cryptoKeys.unmarshalPublicKey(decoded.digest)
-      return this._pubKey
+      if (decoded.name === 'identity') {
+        this._pubKey = cryptoKeys.unmarshalPublicKey(decoded.digest)
+        return this._pubKey
+      }
+    } catch (_) {
+      // Ignore, there is no valid public key
     }
   }
 


### PR DESCRIPTION
`multihash.decode` throws an error, and we are not catching that, this fixes that. We shouldn't need to throw this error. This will occur if no public key exists, and the Id doesn't contain a valid multihash code. The decode was added to unmarshal inline public keys.