### PR TITLE
Add type predicate

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -38,7 +38,7 @@ declare namespace PeerId {
    * Checks if a value is an instance of PeerId.
    * @param id The value to check.
    */
-  function isPeerId(id: any): boolean
+  function isPeerId(id: any): id is PeerId
 
   /**
    * Create a new PeerId.


### PR DESCRIPTION
Tell Typescript that `isPeerId(id)` returns true if, and only if, `id` is of type `PeerId`.

See https://www.typescriptlang.org/docs/handbook/advanced-types.html#using-type-predicates