### PR TITLE
feat(cli): add support for specifying type and size

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
   - [Node.js](#nodejs)
   - [Browser: Browserify, Webpack, other bundlers](#browser-browserify-webpack-other-bundlers)
   - [Browser: `<script>` Tag](#browser-script-tag)
+- [CLI](#cli)
 - [API](#api)
   - [Create](#create)
     - [`new PeerId(id[, privKey, pubKey])`](#new-peeridid-privkey-pubkey)
@@ -117,6 +118,14 @@ the global namespace.
 <script src="https://unpkg.com/peer-id/dist/index.js"></script>
 ```
 
+# CLI
+
+After installing `peer-id`, `npm install peer-id`, you can leverage the cli to generate keys exported as JSON. You can specify the type for the key and size, as detailed in [`create([opts])`](#createopts). The defaults are shown here.
+
+```sh
+> peer-id --type rsa --bits 2048
+```
+
 # API
 
 ```js
@@ -137,7 +146,8 @@ The key format is detailed in [libp2p-crypto](https://github.com/libp2p/js-libp2
 
 Generates a new Peer ID, complete with public/private keypair.
 
-- `opts: Object`: Default: `{bits: 2048, keyType: 'rsa'}`
+- `opts.bits: number` - The size of the key. Default: `2048`
+- `opts.keyType: string` - The key type, one of: `['rsa', 'ed25519', 'secp256k1']`. Default: `rsa`
 
 Returns `Promise<PeerId>`.
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "cids": "^0.8.0",
     "class-is": "^1.1.0",
     "libp2p-crypto": "~0.17.3",
+    "minimist": "^1.2.5",
     "multihashes": "~0.4.15",
     "protons": "^1.0.2"
   },

--- a/src/bin.js
+++ b/src/bin.js
@@ -3,9 +3,13 @@
 'use strict'
 
 const PeerId = require('./index.js')
+const argv = require('minimist')(process.argv.slice(2))
 
 async function main () {
-  const id = await PeerId.create()
+  const id = await PeerId.create({
+    keyType: argv.type,
+    bits: argv.bits
+  })
   console.log(JSON.stringify(id.toJSON(), null, 2)) // eslint-disable-line no-console
 }
 

--- a/test/peer-id.spec.js
+++ b/test/peer-id.spec.js
@@ -63,6 +63,7 @@ describe('PeerId', () => {
     const id = await PeerId.create(testOpts)
     expect(id.toB58String().length).to.equal(46)
     expect(() => {
+      // @ts-ignore
       id.id = Buffer.from('hello')
     }).to.throw(/immutable/)
   })


### PR DESCRIPTION
This adds the ability to specify the key type and size when using the cli.

```console
$ peer-id --type ed25519
{
  "id": "12D3Koo...",
  "privKey": "CAES...",
  "pubKey": "CAE..."
}
```

```console
$ peer-id --type rsa --bits 4096
{
  "id": "Qm...",
  "privKey": "CAA...",
  "pubKey": "CAA..."
}