### PR TITLE
fix: replace node buffers with uint8arrays

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -1,0 +1,7 @@
+'use strict'
+
+module.exports = {
+  bundlesize: {
+    maxSize: '140kB'
+  }
+}

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "cids": "^1.0.0",
     "class-is": "^1.1.0",
-    "libp2p-crypto": "libp2p/js-libp2p-crypto#fix/replace-node-buffers-with-uint8arrays",
+    "libp2p-crypto": "^0.18.0",
     "minimist": "^1.2.5",
     "multihashes": "^3.0.1",
     "protons": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "release-minor": "aegir release --type minor",
     "release-major": "aegir release --type major",
     "coverage": "aegir coverage",
-    "size": "bundlesize -f dist/index.min.js -s 140kB"
+    "size": "aegir build -b"
   },
   "files": [
     "src",
@@ -38,20 +38,17 @@
   "devDependencies": {
     "@types/chai": "^4.2.7",
     "@types/dirty-chai": "^2.0.2",
-    "@types/mocha": "^7.0.2",
-    "aegir": "^22.0.0",
-    "bundlesize": "~0.18.0",
-    "chai": "^4.2.0",
-    "dirty-chai": "^2.0.1"
+    "@types/mocha": "^8.0.1",
+    "aegir": "^25.0.0"
   },
   "dependencies": {
-    "buffer": "^5.5.0",
-    "cids": "^0.8.0",
+    "cids": "^1.0.0",
     "class-is": "^1.1.0",
-    "libp2p-crypto": "^0.17.7",
+    "libp2p-crypto": "libp2p/js-libp2p-crypto#fix/replace-node-buffers-with-uint8arrays",
     "minimist": "^1.2.5",
-    "multihashes": "^1.0.1",
-    "protons": "^1.0.2"
+    "multihashes": "^3.0.1",
+    "protons": "^2.0.0",
+    "uint8arrays": "^1.1.0"
   },
   "repository": {
     "type": "git",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,4 @@
-import crypto, { PrivateKey, PublicKey, KeyType } from "libp2p-crypto";
+import { PrivateKey, PublicKey, KeyType } from "libp2p-crypto";
 import CID from 'cids'
 
 declare namespace PeerId {
@@ -51,36 +51,36 @@ declare namespace PeerId {
    * @param str The input hex string.
    */
   function createFromHexString(str: string): PeerId;
-  
+
   /**
    * Create PeerId from raw bytes.
    * @param buf The raw bytes.
    */
-  function createFromBytes(buf: Buffer): PeerId;
+  function createFromBytes(buf: Uint8Array): PeerId;
 
   /**
    * Create PeerId from base58-encoded string.
    * @param str The base58-encoded string.
    */
   function createFromB58String(str: string): PeerId;
-  
+
   /**
    * Create PeerId from CID.
    * @param cid The CID.
    */
-  function createFromCID(cid: CID | Buffer | string | object): PeerId;
+  function createFromCID(cid: CID | Uint8Array | string | object): PeerId;
 
   /**
    * Create PeerId from public key.
-   * @param key Public key, as Buffer or base64-encoded string.
+   * @param key Public key, as Uint8Array or base64-encoded string.
    */
-  function createFromPubKey(key: Buffer | string): Promise<PeerId>;
+  function createFromPubKey(key: Uint8Array | string): Promise<PeerId>;
 
   /**
    * Create PeerId from private key.
-   * @param key Private key, as Buffer or base64-encoded string.
+   * @param key Private key, as Uint8Array or base64-encoded string.
    */
-  function createFromPrivKey(key: Buffer | string): Promise<PeerId>;
+  function createFromPrivKey(key: Uint8Array | string): Promise<PeerId>;
 
   /**
    * Create PeerId from PeerId JSON formatted object.
@@ -91,21 +91,21 @@ declare namespace PeerId {
 
   /**
    * Create PeerId from Protobuf bytes.
-   * @param buf Protobuf bytes, as Buffer or hex-encoded string.
+   * @param buf Protobuf bytes, as Uint8Array or hex-encoded string.
    */
-  function createFromProtobuf(buf: Buffer | string): Promise<PeerId>;
+  function createFromProtobuf(buf: Uint8Array | string): Promise<PeerId>;
 }
 
 /**
  * PeerId is an object representation of a peer identifier.
  */
 declare class PeerId {
-  constructor(id: Buffer | string, privKey?: PrivateKey, pubKey?: PublicKey);
+  constructor(id: Uint8Array | string, privKey?: PrivateKey, pubKey?: PublicKey);
 
   /**
    * Raw id.
    */
-  readonly id: Buffer;
+  readonly id: Uint8Array;
 
   /**
    * Private key.
@@ -120,18 +120,18 @@ declare class PeerId {
   /**
    * Return the protobuf version of the public key, matching go ipfs formatting.
    */
-  marshalPubKey(): Buffer;
+  marshalPubKey(): Uint8Array;
 
   /**
    * Return the protobuf version of the private key, matching go ipfs formatting.
    */
-  marshalPrivKey(): Buffer;
+  marshalPrivKey(): Uint8Array;
 
   /**
    * Return the protobuf version of the peer-id.
    * @param excludePriv Whether to exclude the private key information from the output.
    */
-  marshal(excludePriv?: boolean): Buffer;
+  marshal(excludePriv?: boolean): Uint8Array;
 
   /**
    * String representation.
@@ -153,7 +153,7 @@ declare class PeerId {
   /**
    * Return raw id bytes.
    */
-  toBytes(): Buffer;
+  toBytes(): Uint8Array;
 
   /**
    * Encode to base58 string.
@@ -170,14 +170,14 @@ declare class PeerId {
    * Checks the equality of `this` peer against a given PeerId.
    * @param id The other PeerId.
    */
-  equals(id: PeerId | Buffer): boolean;
+  equals(id: PeerId | Uint8Array): boolean;
 
   /**
    * Checks the equality of `this` peer against a given PeerId.
    * @deprecated Use {.equals}
    * @param id The other PeerId.
    */
-  isEqual(id: PeerId | Buffer): boolean;
+  isEqual(id: PeerId | Uint8Array): boolean;
 
   /**
    * Check if this PeerId instance is valid (privKey -> pubKey -> Id)


### PR DESCRIPTION
Replaces all uses of node Buffers with Uint8Arrays

Depends on:

- [x] https://github.com/libp2p/js-libp2p-crypto/pull/180

BREAKING CHANGES:

- Where node Buffers were returned, now Uint8Arrays are