### PR TITLE
fix: privKey possible undefined

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -31,7 +31,7 @@ declare namespace PeerId {
     /**
      * Private key.
      */
-    privKey: string;
+    privKey?: string;
   };
 
   /**


### PR DESCRIPTION
If `pubKey` can be undefined then the `privKey` should be possible to have undefined as well.