### PR TITLE
feat: has inline public key method

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -183,6 +183,11 @@ declare class PeerId {
    * Check if this PeerId instance is valid (privKey -> pubKey -> Id)
    */
   isValid(): boolean;
+
+  /**
+   * Check if the PeerId has an inline public key.
+   */
+  hasInlinePublicKey(): boolean;
 }
 
 export = PeerId;

--- a/src/index.js
+++ b/src/index.js
@@ -178,6 +178,23 @@ class PeerId {
       this.pubKey.bytes instanceof Uint8Array &&
         uint8ArrayEquals(this.privKey.public.bytes, this.pubKey.bytes))
   }
+
+  /**
+   * Check if the PeerId has an inline public key.
+   * @returns {boolean}
+   */
+  hasInlinePublicKey () {
+    try {
+      const decoded = mh.decode(this.id)
+      if (decoded.name === 'identity') {
+        return true
+      }
+    } catch (_) {
+      // Ignore, there is no valid public key
+    }
+
+    return false
+  }
 }
 
 const PeerIdWithIs = withIs(PeerId, {

--- a/test/peer-id.spec.js
+++ b/test/peer-id.spec.js
@@ -243,6 +243,18 @@ describe('PeerId', () => {
     expect(ids[0].equals(ids[1].id)).to.equal(false)
   })
 
+  describe('hasInlinePublicKey', () => {
+    it('returns true if uses a key type with inline public key', async () => {
+      const peerId = await PeerId.create({ keyType: 'secp256k1' })
+      expect(peerId.hasInlinePublicKey()).to.equal(true)
+    })
+
+    it('returns false if uses a key type with no inline public key', async () => {
+      const peerId = await PeerId.create({ keyType: 'RSA' })
+      expect(peerId.hasInlinePublicKey()).to.equal(false)
+    })
+  })
+
   describe('fromJSON', () => {
     it('full node', async () => {
       const id = await PeerId.create(testOpts)


### PR DESCRIPTION
There are several use cases where it is important to know if the peerId has inline public key

Closes #131 