### PR TITLE
fix: remove toString side effect that breaks deep equals

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -137,7 +137,11 @@ class PeerId {
   toString () {
     if (!this._idCIDString) {
       const cid = new CID(1, 'libp2p-key', this.id, 'base32')
-      this._idCIDString = cid.toBaseEncodedString('base32')
+
+      Object.defineProperty(this, '_idCIDString', {
+        value: cid.toBaseEncodedString('base32'),
+        enumerable: false
+      })
     }
     return this._idCIDString
   }

--- a/test/peer-id.spec.js
+++ b/test/peer-id.spec.js
@@ -309,6 +309,18 @@ describe('PeerId', () => {
     expect(peerId.isValid()).to.equal(false)
   })
 
+  it('keys are equal after one is stringified', async () => {
+    const peerId = await PeerId.create(testOpts)
+    const peerId1 = PeerId.createFromB58String(peerId.toB58String())
+    const peerId2 = PeerId.createFromB58String(peerId.toB58String())
+
+    expect(peerId1).to.deep.equal(peerId2)
+
+    peerId1.toString()
+
+    expect(peerId1).to.deep.equal(peerId2)
+  })
+
   describe('returns error via cb instead of crashing', () => {
     const garbage = [
       uint8ArrayFromString('00010203040506070809', 'base16'),


### PR DESCRIPTION
Makes the cached string cid property non-enumerable so deep equals
still works even after a peer id has been stringifed.

Fixes #141