### PR TITLE
Use undefined instead of null privKey

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -314,7 +314,7 @@ exports.createFromPubKey = async (key) => {
   }
 
   const pubKey = await cryptoKeys.unmarshalPublicKey(buf)
-  return computePeerId(null, pubKey)
+  return computePeerId(undefined, pubKey)
 }
 
 // Private key input will be a string
@@ -338,7 +338,7 @@ exports.createFromJSON = async (obj) => {
   const pub = rawPubKey && await cryptoKeys.unmarshalPublicKey(rawPubKey)
 
   if (!rawPrivKey) {
-    return new PeerIdWithIs(id, null, pub)
+    return new PeerIdWithIs(id, undefined, pub)
   }
 
   const privKey = await cryptoKeys.unmarshalPrivateKey(rawPrivKey)
@@ -394,7 +394,7 @@ exports.createFromProtobuf = async (buf) => {
   // TODO: val id and pubDigest
 
   if (pubKey) {
-    return new PeerIdWithIs(pubDigest, null, pubKey)
+    return new PeerIdWithIs(pubDigest, undefined, pubKey)
   }
 
   if (id) {


### PR DESCRIPTION
Respect the `PeerId#privKey` typescript type, which is `PrivateKey | undefined`, not `PrivateKey | null`

Found this in the course of manually creating a peer id using typescript.

```ts
import {expect} from "chai";
import PeerId from "peer-id";
import mh from "multihashes";
import { keys } from "libp2p-crypto";
const { supportedKeys } = keys;

async function test () {
  const privKey = await supportedKeys.secp256k1.generateKeyPair();
  const pubKey = privKey.public;
  const id = mh.encode(pubKey.bytes, "identity");

  // these two should be identical
  const manualPeerId = new PeerId(id, undefined, pubKey); 
  const peerId = await PeerId.createFromPubKey(pubKey.bytes);

  // but they aren't
  expect(manualPeerId).to.deep.equal(peerId);
  // replace 'undefined' with 'null as any' to avoid error
}

test();
```