### PR TITLE
chore: update libp2p-crypto

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,12 +41,12 @@
     "@types/chai": "^4.2.21",
     "@types/dirty-chai": "^2.0.2",
     "@types/mocha": "^9.0.0",
-    "aegir": "^35.0.1",
+    "aegir": "^36.0.1",
     "util": "^0.12.3"
   },
   "dependencies": {
     "class-is": "^1.1.0",
-    "libp2p-crypto": "^0.19.0",
+    "libp2p-crypto": "^0.20.0",
     "minimist": "^1.2.5",
     "multiformats": "^9.4.5",
     "protobufjs": "^6.10.2",

--- a/package.json
+++ b/package.json
@@ -38,9 +38,6 @@
   },
   "homepage": "https://github.com/libp2p/js-peer-id",
   "devDependencies": {
-    "@types/chai": "^4.2.21",
-    "@types/dirty-chai": "^2.0.2",
-    "@types/mocha": "^9.0.0",
     "aegir": "^36.0.1",
     "util": "^0.12.3"
   },


### PR DESCRIPTION
Pulls in libp2p-crypto@0.20.0 which is smaller and faster