### PR TITLE
chore: remove pre-gyp from ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,6 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node }}
-      - run: npm install @mapbox/node-pre-gyp -g
       - run: npm install
       - run: npx aegir test -t node --cov --bail
       - uses: codecov/codecov-action@v1


### PR DESCRIPTION
`ursa-optional` has gone from the dep tree so @mapbox/node-pre-gyp shouldn't be required now.